### PR TITLE
Fixed hyperlinks

### DIFF
--- a/code-blocks/code-block-index.md
+++ b/code-blocks/code-block-index.md
@@ -132,9 +132,9 @@ There are various pages for code blocks. You can find them below.
   
 #### Miscellaneous
 
-* [Comment](code-blocks/miscellaneous/miscellaneous/comment.md)
-* [Get Roblox Version](code-blocks/miscellaneous/miscellaneous/get-roblox-version.md)
-* [Insert Model](code-blocks/miscellaneous/miscellaneous/insert-model.md)
-* [Is game loaded](code-blocks/miscellaneous/miscellaneous/is-game-loaded.md)
-* [Is Studio](code-blocks/miscellaneous/miscellaneous/is-studio.md)
-* [Reload Place](code-blocks/miscellaneous/miscellaneous/reload-place.md)
+* [Comment](miscellaneous/miscellaneous/comment.md)
+* [Get Roblox Version](miscellaneous/miscellaneous/get-roblox-version.md)
+* [Insert Model](miscellaneous/miscellaneous/insert-model.md)
+* [Is game loaded](miscellaneous/miscellaneous/is-game-loaded.md)
+* [Is Studio](miscellaneous/miscellaneous/is-studio.md)
+* [Reload Place](miscellaneous/miscellaneous/reload-place.md)


### PR DESCRIPTION
# Fixed some broken hyperlinks for the `code-block-index.md` file

My pull request is to
- [ ] Add documentation
- [X] Fix documentation

If adding documenation, I am adding it to
- [ ] Code blocks
- [ ] Objects
- [ ] Guides
<!---
 Select by adding an X into the box, for example:
 - [x] Thing
-->
If adding documentation, did I
- [ ] Correctly format the page to match the other ones
- [ ] Add it to the index page for the correct category
- [ ] Add it to SUMMARY.md

# Additional information

--- Fixed hyperlinks for the /miscellaneous/miscellaneous/ code blocks in the `code-block-index.md` file so they work now
